### PR TITLE
Add SQLAlchemy persistence for activities (Activity/Participant models)

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,27 @@
+[alembic]
+script_location = alembic
+
+[alembic:runtime]
+sqlalchemy.url = %(MAIN_DB_URI)s
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,51 @@
+from __future__ import with_statement
+import os
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from src.db import Base
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+target_metadata = Base.metadata
+
+
+def run_migrations_offline():
+    url = config.get_main_option("sqlalchemy.url") or os.getenv("MAIN_DB_URI")
+    context.configure(
+        url=url, target_metadata=target_metadata, literal_binds=True
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    configuration = config.get_section(config.config_ini_section)
+    if not configuration.get("sqlalchemy.url"):
+        configuration["sqlalchemy.url"] = os.getenv("MAIN_DB_URI") or f"sqlite:///mergington.db"
+
+    connectable = engine_from_config(
+        configuration, prefix="sqlalchemy.", poolclass=pool.NullPool
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+SQLAlchemy
+alembic

--- a/src/app.py
+++ b/src/app.py
@@ -1,81 +1,134 @@
 """
-High School Management System API
+Mergington High - Activity API (DB-backed)
 
-A super simple FastAPI application that allows students to view and sign up
-for extracurricular activities at Mergington High School.
+This module replaces the previous in-memory data store with a simple SQLAlchemy
+backed model using SQLite by default. On startup it creates tables and seeds
+the database with the original activity fixtures if the DB is empty.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
 import os
 from pathlib import Path
 
-app = FastAPI(title="Mergington High School API",
-              description="API for viewing and signing up for extracurricular activities")
+from .db import engine, SessionLocal, Base
+from .models import Activity, Participant
 
-# Mount the static files directory
-current_dir = Path(__file__).parent
-app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
-          "static")), name="static")
+app = FastAPI(
+    title="Mergington High School API",
+    description="API for viewing and signing up for extracurricular activities",
+)
 
-# In-memory activity database
-activities = {
+# Mount the static files directory (unchanged behaviour)
+app.mount(
+    "/static", StaticFiles(directory=os.path.join(Path(__file__).parent, "static")), name="static"
+)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# Original fixtures (used for DB seeding if empty)
+initial_activities = {
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+        "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
     },
     "Programming Class": {
         "description": "Learn programming fundamentals and build software projects",
         "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
         "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
+        "participants": ["emma@mergington.edu", "sophia@mergington.edu"],
     },
     "Gym Class": {
         "description": "Physical education and sports activities",
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+        "participants": ["john@mergington.edu", "olivia@mergington.edu"],
     },
     "Soccer Team": {
         "description": "Join the school soccer team and compete in matches",
         "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
         "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"],
     },
     "Basketball Team": {
         "description": "Practice and play basketball with the school team",
         "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"],
     },
     "Art Club": {
         "description": "Explore your creativity through painting and drawing",
         "schedule": "Thursdays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"],
     },
     "Drama Club": {
         "description": "Act, direct, and produce plays and performances",
         "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
         "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
+        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"],
     },
     "Math Club": {
         "description": "Solve challenging problems and participate in math competitions",
         "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
         "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
+        "participants": ["james@mergington.edu", "benjamin@mergington.edu"],
     },
     "Debate Team": {
         "description": "Develop public speaking and argumentation skills",
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
+        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"],
+    },
 }
+
+
+@app.on_event("startup")
+def on_startup():
+    # Create tables
+    Base.metadata.create_all(bind=engine)
+
+    # Seed database if empty
+    db = SessionLocal()
+    try:
+        count = db.query(Activity).count()
+        if count == 0:
+            for name, meta in initial_activities.items():
+                act = Activity(
+                    name=name,
+                    description=meta.get("description"),
+                    schedule=meta.get("schedule"),
+                    max_participants=meta.get("max_participants", 0),
+                )
+                db.add(act)
+                db.flush()
+                for email in meta.get("participants", []):
+                    db.add(Participant(email=email, activity_id=act.id))
+            db.commit()
+    finally:
+        db.close()
+
+
+def activity_to_dict(activity: Activity):
+    return {
+        activity.name: {
+            "description": activity.description,
+            "schedule": activity.schedule,
+            "max_participants": activity.max_participants,
+            "participants": [p.email for p in activity.participants],
+        }
+    }
 
 
 @app.get("/")
@@ -84,49 +137,46 @@ def root():
 
 
 @app.get("/activities")
-def get_activities():
-    return activities
+def get_activities(db: Session = Depends(get_db)):
+    activities = db.query(Activity).all()
+    merged = {}
+    for a in activities:
+        merged.update(activity_to_dict(a))
+    return merged
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
+def signup_for_activity(activity_name: str, email: str, db: Session = Depends(get_db)):
     # Validate activity exists
-    if activity_name not in activities:
+    activity = db.query(Activity).filter(Activity.name == activity_name).first()
+    if not activity:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
-
     # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
+    if any(p.email == email for p in activity.participants):
+        raise HTTPException(status_code=400, detail="Student is already signed up")
 
-    # Add student
-    activity["participants"].append(email)
+    # Validate capacity
+    if activity.max_participants and len(activity.participants) >= activity.max_participants:
+        raise HTTPException(status_code=400, detail="Activity is full")
+
+    participant = Participant(email=email, activity_id=activity.id)
+    db.add(participant)
+    db.commit()
+    db.refresh(activity)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
+def unregister_from_activity(activity_name: str, email: str, db: Session = Depends(get_db)):
+    activity = db.query(Activity).filter(Activity.name == activity_name).first()
+    if not activity:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+    participant = db.query(Participant).filter(Participant.activity_id == activity.id, Participant.email == email).first()
+    if not participant:
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
-    activity["participants"].remove(email)
+    db.delete(participant)
+    db.commit()
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,22 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+# Default to a local SQLite file if MAIN_DB_URI is not set
+DEFAULT_SQLITE_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "mergington.db")
+)
+DATABASE_URL = os.getenv("MAIN_DB_URI", f"sqlite:///{DEFAULT_SQLITE_PATH}")
+
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,23 @@
+from sqlalchemy import Column, Integer, String, Text, ForeignKey
+from sqlalchemy.orm import relationship
+from .db import Base
+
+
+class Activity(Base):
+    __tablename__ = "activities"
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True, nullable=False)
+    description = Column(Text)
+    schedule = Column(String)
+    max_participants = Column(Integer, default=0)
+    participants = relationship(
+        "Participant", back_populates="activity", cascade="all, delete-orphan"
+    )
+
+
+class Participant(Base):
+    __tablename__ = "participants"
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, index=True, nullable=False)
+    activity_id = Column(Integer, ForeignKey("activities.id"))
+    activity = relationship("Activity", back_populates="participants")


### PR DESCRIPTION
This PR adds a small SQLAlchemy-based persistence layer for activities and participants and a minimal Alembic scaffold.

What changed:
- `src/db.py`: SQLAlchemy engine, session and Base (default SQLite at `mergington.db`)
- `src/models.py`: Activity and Participant ORM models
- `src/app.py`: refactored to use DB-backed models, startup DB seeding with the original fixtures, endpoints updated to use DB sessions
- `requirements.txt`: added `SQLAlchemy` and `alembic`
- `alembic/` and `alembic.ini`: minimal Alembic scaffold to support future migrations

Why:
- Replaces the in-memory activities dict so signups persist across restarts and unlocks future features (migrations, CSV exports, admin UI).

Testing notes:
- On startup the app will create `mergington.db` (SQLite) and seed activities if DB is empty.
- Quick syntax check performed. To run locally:

  1. Install dependencies: `pip install -r requirements.txt`
  2. Start the app: `uvicorn src.app:app --reload`
  3. Visit `GET /activities` and try `POST /activities/{name}/signup?email=you@example.com`

If this looks good I can follow up with:
- an Alembic initial migration generated from models
- a small test suite and CSV export endpoint

